### PR TITLE
fix: install dependencies in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
       - uses: changesets/action@v1
         with:
           publish: npm publish


### PR DESCRIPTION
## Summary
- ensure release workflow installs deps before running changesets

## Testing
- `npm test`
- `npm run format:check`